### PR TITLE
Contact and address as fallback from parent

### DIFF
--- a/lang/de/local_entities.php
+++ b/lang/de/local_entities.php
@@ -43,6 +43,7 @@ $string['address_streetnumber'] = 'Haus-Nr.';
 $string['address_map_link'] = 'Karten-Link';
 $string['address_map_embed'] = 'Karte einbetten (HTML)';
 $string['affiliated'] = 'Zugehörige Orte';
+$string['belongs_to'] = 'Gehört zu';
 $string['contacts'] = 'Kontakte';
 $string['contacts_givenname'] = 'Vorname';
 $string['contacts_surname'] = 'Nachname';
@@ -86,6 +87,14 @@ $string['errorwiththefollowingdates'] = 'Es gibt einen Konflikt mit den folgende
 
 $string['maxallocation'] = 'Maximale Anzahl möglicher Buchungen.';
 $string['maxallocation_help'] = '0 für kein Limit, -1 bedeutet nicht buchbar';
+
+//Settings
+$string['fallback_image_parent'] = 'Bild der übergeordneten Entity als Fallback verwenden';
+$string['fallback_image_parent:description'] = 'Wenn die Option gesetzt ist, wird, wenn keine Bild angegeben ist, das Bild der übergeordneten Entity verwendet.';
+$string['fallback_contacts_parent'] = 'Kontakte der übergeordneten Entity als Fallback verwenden';
+$string['fallback_contacts_parent:description'] = 'Wenn die Option gesetzt ist, werden, wenn keine Kontaktdaten angegeben sind, die Kontaktdaten der übergeordneten Entity verwendet.';
+$string['fallback_address_parent'] = 'Adresse der übergeordneten Entity als Fallback verwenden';
+$string['fallback_address_parent:description'] = 'Wenn die Option gesetzt ist, werden, wenn keine Adressdaten angegeben sind, die Adressdaten der übergeordneten Entity verwendet.';
 
 // Access.php.
 $string['entities:edit'] = 'Nutzer*in darf Entities editieren.';

--- a/lang/en/local_entities.php
+++ b/lang/en/local_entities.php
@@ -43,6 +43,7 @@ $string['address_streetnumber'] = 'Street number';
 $string['address_map_link'] = 'Maps link';
 $string['address_map_embed'] = 'Embed map (HTML)';
 $string['affiliated'] = 'Affiliated locations';
+$string['belongs_to'] = 'Belongs to';
 $string['contacts'] = 'Contacts';
 $string['contacts_givenname'] = 'Given name';
 $string['contacts_surname'] = 'Surname';
@@ -87,6 +88,14 @@ $string['errorwiththefollowingdates'] = 'There is a conflict with the following 
 
 $string['maxallocation'] = 'Max number of bookings on this entity';
 $string['maxallocation_help'] = '0 for no limit, -1 for not bookable.';
+
+//Settings
+$string['fallback_image_parent'] = 'Use image of parent entity as fallback';
+$string['fallback_image_parent:description'] = 'If enabled and there is no image, the image of the parent entity is used.';
+$string['fallback_contacts_parent'] = 'Use contacts of parent entity as fallback';
+$string['fallback_contacts_parent:description'] = 'If enabled and there are not contact information, the contact information of the parent entity is used';
+$string['fallback_address_parent'] = 'Use address of parent entity as fallback';
+$string['fallback_address_parent:description'] = 'If enabled and there is not address, the address of the parent entity is used';
 
 // Access.php.
 $string['entities:edit'] = 'User is allowed to edit entities';

--- a/settings.php
+++ b/settings.php
@@ -48,4 +48,31 @@ if ($hassiteconfig) {
             )
         );
     }
+
+    $settings->add(
+        new admin_setting_configcheckbox(
+            $componentname .'/fallback_image_parent',
+            get_string('fallback_image_parent', $componentname),
+            get_string('fallback_image_parent:description', $componentname),
+            1
+        )
+    );
+
+    $settings->add(
+        new admin_setting_configcheckbox(
+            $componentname .'/fallback_address_parent',
+            get_string('fallback_address_parent', $componentname),
+            get_string('fallback_address_parent:description', $componentname),
+            1
+        )
+    );
+
+    $settings->add(
+        new admin_setting_configcheckbox(
+            $componentname .'/fallback_contacts_parent',
+            get_string('fallback_contacts_parent', $componentname),
+            get_string('fallback_contacts_parent:description', $componentname),
+            1
+        )
+    );
 }

--- a/templates/view.mustache
+++ b/templates/view.mustache
@@ -95,7 +95,12 @@
         </div>
         {{/metadata}}
         </div>
-        
+
+        {{#parent}}
+            <h5>{{#str}} belongs_to, local_entities {{/str}}</h5>
+            <a href="{{link}}">{{name}} ({{shortname}})</a>
+        {{/parent}}
+
         {{#affiliated}}
         <h5>{{#str}} affiliated, local_entities {{/str}}</h5>
             <div class="row">

--- a/version.php
+++ b/version.php
@@ -27,6 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_entities';
 $plugin->release = '0.1.6';
-$plugin->version = 2023031600;
+$plugin->version = 2023040300;
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_ALPHA;

--- a/view.php
+++ b/view.php
@@ -105,19 +105,53 @@ if (!empty($subentities)) {
     $entity->affiliated = $affiliated;
 }
 
+// Parent Entity
+$imagefallback = get_config('local_entities', 'fallback_image_parent');
+$contactsfallback = get_config('local_entities', 'fallback_contacts_parent');
+$addressfallback = get_config('local_entities', 'fallback_address_parent');
+
+if(!empty($entity->parentid)){
+$parent = \local_entities\settings_manager::get_settings($entity->parentid);
+if(!empty($parent)){
+
+    $entity->parent = $parent;
+    $entity->parent->link = new \moodle_url("/local/entities/view.php", array("id" => $parent->id));
+    $parenthasaddress = !empty($parent->address);
+    $parenthascontacts = !empty($parent->contacts);
+
+    if(!isset($url) && $imagefallback){
+        $url = $files = $fs->get_area_files($context->id, 'local_entities', 'image', $parent->id);
+
+        foreach ($files as $file) {
+            $filename = $file->get_filename();
+            if ($file->get_filesize() > 0) {
+                $url = moodle_url::make_file_url('/pluginfile.php', '/1/local_entities/image/' . $parent->id . '/' . $filename);
+            }
+        }
+    }
+}
+}
+
 $entity->metadata = $metadata;
 $entity->description = file_rewrite_pluginfile_urls($entity->description, 'pluginfile.php',
 $context->id, 'local_entity', 'description', null);
 
 $entity->picture = isset($url) ? $url : null;
-$entity->hasaddress = isset($entity->address);
-$entity->hascontacts = isset($entity->contacts);
+$entity->hasaddress = !empty($entity->address);
+$entity->hascontacts = !empty($entity->contacts);
 $entity->haspicture = isset($entity->picture);
+
 if ($entity->hasaddress) {
     $entity->addresscleaned = array_values($entity->address);
+}else if($parenthasaddress && $addressfallback){
+    $entity->hasaddress = $parenthasaddress;
+    $entity->addresscleaned = array_values($parent->address);
 }
 if ($entity->hascontacts) {
     $entity->contactscleaned = array_values($entity->contacts);
+}else if($parenthascontacts && $contactsfallback){
+    $entity->hascontacts = $parenthascontacts;
+    $entity->contactscleaned = array_values($parent->contacts);
 }
 
 $entity->canedit = has_capability('local/entities:edit', \context_system::instance());


### PR DESCRIPTION
- If there is no image, address or contact, they can be used from the parent.
- Link to parent will be shown on the page.

FIX: It seems that even there is no data for address or contact, there will be always a entry in the database. I switched from "isset" to "!empty" so that "hasaddress" and "hascontacts" is set correctly