### PR TITLE
Fixes the Type Error Bug with PHP 8

### DIFF
--- a/classes/form/edit_dynamic_form.php
+++ b/classes/form/edit_dynamic_form.php
@@ -298,15 +298,17 @@ class edit_dynamic_form extends dynamic_form {
         $events = [];
         $eventarray = [];
         for ($i = 0; $i < count($data->daysofweek); $i++) {
-            $eventarray['title'] = 'openinghours';
-            $eventarray['daysofweek'] = implode(',', $data->daysofweek[$i]);
-            $eventarray['starthours'] = sprintf("%02d", $data->starthours[$i]);
-            $eventarray['startminutes'] = sprintf("%02d", $data->startminutes[$i]);
-            $eventarray['endhours'] = sprintf("%02d", $data->endhours[$i]);
-            $eventarray['endminutes'] = sprintf("%02d", $data->endminutes[$i]);
-            if ($eventarray['starthours'].$eventarray['startminutes'] !=
-            $eventarray['endhours'].$eventarray['endminutes']) {
-                $events[] = new reoccuringevent($eventarray);
+            if(is_array($data->daysofweek[$i])) {
+                $eventarray['title'] = 'openinghours';
+                $eventarray['daysofweek'] = implode(',', $data->daysofweek[$i]);
+                $eventarray['starthours'] = sprintf("%02d", $data->starthours[$i]);
+                $eventarray['startminutes'] = sprintf("%02d", $data->startminutes[$i]);
+                $eventarray['endhours'] = sprintf("%02d", $data->endhours[$i]);
+                $eventarray['endminutes'] = sprintf("%02d", $data->endminutes[$i]);
+                if ($eventarray['starthours'] . $eventarray['startminutes'] !=
+                    $eventarray['endhours'] . $eventarray['endminutes']) {
+                    $events[] = new reoccuringevent($eventarray);
+                }
             }
         }
         if (!empty($events)) {


### PR DESCRIPTION
PHP 8 throws an exception if the type of a parameter for a internal function is wrong.

https://wiki.php.net/rfc/consistent_type_errors

